### PR TITLE
Strip leading +49 and 0 from user input

### DIFF
--- a/main.py
+++ b/main.py
@@ -429,7 +429,7 @@ def main():
             "hausnummer": hausnummer,
             "plz": wohnort_plz,
             "ort": wohnort,
-            "phone": "+49" + str(telefonnummer),
+            "phone": "+49" + str(telefonnummer).removeprefix("+49").removeprefix("0"),
             "notificationChannel": "email",
             "notificationReceiver": mail,
         }


### PR DESCRIPTION
I don't think it's a problem but it's worth nothing that this requires Python 3.9: https://docs.python.org/3.9/library/stdtypes.html?highlight=removeprefix#str.removeprefix 
