### PR TITLE
Make the check_delay parameter configurable

### DIFF
--- a/main.py
+++ b/main.py
@@ -768,7 +768,7 @@ def run_search_interactive():
     return run_search(kontaktdaten)
 
 
-def run_search(kontaktdaten):
+def run_search(kontaktdaten, check_delay=30):
     """
     Nicht-interaktive Terminsuche
 
@@ -798,7 +798,7 @@ def run_search(kontaktdaten):
         raise exc
 
     ImpfterminService.terminsuche(code=code, plz_impfzentren=plz_impfzentren, kontakt=kontakt,
-                                  check_delay=30)
+                                  check_delay=check_delay)
 
 
 def gen_code_interactive():
@@ -903,6 +903,11 @@ def main():
         "--configure-only",
         action='store_true',
         help="Nur Kontaktdaten erfassen und in JSON-Datei abspeichern")
+    parser_search.add_argument(
+        "--retry-sec", "-r",
+        type=int,
+        default=30,
+        help="Wartezeit zwischen zwei Versuchen (in Sekunden)")
 
     parser_code = subparsers.add_parser("code", help="Impf-Code generieren")
     parser_code.add_argument(
@@ -920,7 +925,7 @@ def main():
         if args.configure_only:
             update_kontaktdaten_interactive({}, "search", args.file)
         elif args.file:
-            run_search(get_kontaktdaten(args.file))
+            run_search(get_kontaktdaten(args.file), check_delay=args.retry_sec)
         else:
             run_search_interactive()
 

--- a/main.py
+++ b/main.py
@@ -768,7 +768,7 @@ def run_search_interactive():
     return run_search(kontaktdaten)
 
 
-def run_search(kontaktdaten, check_delay=30):
+def run_search(kontaktdaten, check_delay=60):
     """
     Nicht-interaktive Terminsuche
 
@@ -906,7 +906,7 @@ def main():
     parser_search.add_argument(
         "--retry-sec", "-r",
         type=int,
-        default=30,
+        default=60,
         help="Wartezeit zwischen zwei Versuchen (in Sekunden)")
 
     parser_code = subparsers.add_parser("code", help="Impf-Code generieren")


### PR DESCRIPTION
## Abstract

This makes the currently hardcoded value of delay time between two consecutive attempts configurable, using a default value of 30 seconds, also to be backwards compatible.

## Rationale

In some cases (especially when running multiple instances of the script using the "profile" option) the default value of 30 seconds is too aggressive, leading to 429 responses from the remote server.

## Usage

Basically there is just another optional command line argument `--retry-sec`:

```
% python3 main.py search -h
vaccipy - Automatische Terminbuchung für den Corona Impfterminservice

usage: main.py search [-h] [-f FILE] [--configure-only] [--retry-sec RETRY_SEC]

optional arguments:
  -h, --help            show this help message and exit
  -f FILE, --file FILE  Pfad zur JSON-Datei für Kontaktdaten
  --configure-only      Nur Kontaktdaten erfassen und in JSON-Datei abspeichern
  --retry-sec RETRY_SEC, -r RETRY_SEC
                        Wartezeit zwischen zwei Versuchen (in Sekunden)
```

## Discussion

For my use case the sweet spot is around 50 seconds using 2 distinct profiles in parallel, being able to run the two instances for several hours without issues.