### PR TITLE
feat(beepy): Play coin sound when appointment is found

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -15,6 +15,19 @@ let
 
   my-python = python3.override {
     packageOverrides = self: super: {
+      beepy = buildPythonPackage rec {
+        pname = "beepy";
+        version = "1.0.7";
+        src = fetchPypi {
+          inherit pname version;
+          sha256 = "0psv1na3cygarh7h42nc1zigsqmpj99c2yyys6lar6607kzlhww1";
+        };
+        doCheck = false;
+        propagatedBuildInputs = [
+          super.simpleaudio
+        ];
+      };
+
       cloudscraper = buildPythonPackage rec {
         pname = "cloudscraper";
         version = "1.2.58";
@@ -58,6 +71,7 @@ mkShell {
   buildInputs = [
     chromium
     (my-python.withPackages (p: [
+      p.beepy
       p.certifi
       p.chardet
       p.cloudscraper

--- a/tools/its.py
+++ b/tools/its.py
@@ -20,6 +20,12 @@ from selenium.webdriver.support.ui import WebDriverWait
 from tools.clog import CLogger
 from tools.utils import retry_on_failure, desktop_notification
 
+try:
+    import beepy
+    ENABLE_BEEPY = True
+except ImportError:
+    ENABLE_BEEPY = False
+
 class ImpfterminService():
     def __init__(self, code: str, plz_impfzentren: list, kontakt: dict,PATH:str):
         self.code = str(code).upper()
@@ -476,6 +482,8 @@ class ImpfterminService():
                     ts = datetime.fromtimestamp(termin["begin"] / 1000).strftime(
                         '%d.%m.%Y um %H:%M Uhr')
                     self.log.success(f"{num}. Termin: {ts}")
+                if ENABLE_BEEPY:
+                    beepy.beep('coin')
                 return True, 200
             else:
                 self.log.info(f"Keine Termine verfügbar in {plz}")


### PR DESCRIPTION
[cherry-pick of #103 against beta]

Discussion:

> apparently on Debian, installing beepy with pip requires the package python3-dev and libasound2-dev. Not sure what's required on other distros. So not sure if we want this feature. Can we make it optional, i.e. available if the user has beepy installed?