### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ pip3 install -r requirements.txt
 ```
 
 ## Ausführung unter Windows
-1) [`vaccipy` downloaden](##Downloads)
+1) [`vaccipy` downloaden](#Downloads)
 2) .zip Ordner entpacken
 3) Im `windows-terminservice\`-Ordner die `windows-terminservice.exe` ausführen. 
 


### PR DESCRIPTION
Es war ein "#" bei einem Link zu viel, dadurch wurde der Titel nicht richtig verlinkt.
Siehe #122 

Alternativ könnte man auch direkt [https://cntr.click/9ypzBLb](https://cntr.click/9ypzBLb) einfügen, würde das aber so lassen, da man in der Readme dadurch nur ein download link verwalten muss, falls der sich ändern sollte

Und im Beta Branch steht der Text so auch gar nicht mehr drin