### PR TITLE
docs: Mehr info zum Ausführen der Executables unter Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,14 @@ pip3 install -r requirements.txt
 > 
 > "[...] Um das Tool dann zum Laufen zu bringen, könntest du zum Beispiel eine [Ausnahme in den Windows-Sicherheiteinstellungen hinzufügen.](https://support.microsoft.com/de-de/windows/hinzufügen-eines-ausschlusses-zu-windows-sicherheit-811816c0-4dfd-af4a-47e4-c301afe13b26)"
 
+## Ausführung unter Linux 
+1) [`vaccipy` downloaden](#Downloads)
+2) .zip Ordner entpacken
+3) Eventuell notwendig: Die Terminservice- und Driver-Executable ausführbar machen.
+Dazu das Terminal zum `linux-64-terminservice`-Ordner navigieren und folgenden Befehl ausführen:  
+  `sudo -- sh -c 'chmod +x ./linux-64-terminservice; chmod +x ./tools/chromedriver/chromedriver-linux-64'`
+4) Im `linux-64-terminservice`-Ordner die `./linux-64-terminsvervice`-Executable per Terminal ausführen. 
+
 ## Ausführung in der Kommandozeile
 
 `vaccipy` kannst du über die Kommandozeile oder in einer beliebigen python-Entwicklungsumgebung

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -18,6 +18,12 @@ Verfügbare Distributionen:
 - .zip Ordner entpacken
 - Im `windows-terminservice\`-Ordner die `windows-terminservice.exe` ausführen. 
 
+**Ausführung Linux:**
+- .zip Ordner entpacken
+- Eventuell notwendig: Die Terminservice- und Driver-Executable ausführbar machen.
+Dazu das Terminal zum `linux-64-terminservice`-Ordner navigieren und folgende Befehle ausführen:  
+  `sudo -- sh -c 'chmod +x ./linux-64-terminservice; chmod +x ./tools/chromedriver/chromedriver-linux-64'`
+- Im `linux-64-terminservice`-Ordner die `./linux-64-terminsvervice` executable per Terminal ausführen. 
 
 Für mehr Info zum Verteilen und Erstellen der Distributionen: [Shipping](#Shipping)
 


### PR DESCRIPTION
Mir ist aufgefallen, dass man unter Linux die executables erst executable machen muss und dafür hab ich den passenden command schonmal convenience-mäßig in die docs eingefügt. 