### PR TITLE
BELL-Fallback für Beepy

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -530,6 +530,8 @@ class ImpfterminService():
                     self.log.success(f"{num}. Termin: {ts}")
                 if ENABLE_BEEPY:
                     beepy.beep('coin')
+                else:
+                    print("\a")
                 return True, 200
             else:
                 self.log.info(f"Keine Termine verfügbar in {plz}")


### PR DESCRIPTION
Wenn Beepy nicht funktioniert, wird versucht, stattdessen einen Piep über das BELL-Steuerzeichen auszugeben. Hat mir gerade einen Termin gerettet.