### PR TITLE
Neuer cookie wenn Buchung/Code bestätigen fehlschlägt

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -617,6 +617,17 @@ class ImpfterminService():
 
         elif res.status_code == 429:
             msg = "Anfrage wurde von der Botprotection geblockt."
+            self.log.error(msg)
+            self.renew_cookies_code()
+            res = self.s.post(self.domain + path, json=data, timeout=15)
+            if res.status_code == 201:
+                msg = "Termin erfolgreich gebucht!"
+                self.log.success(msg)
+                desktop_notification(operating_system=self.operating_system, title="Terminbuchung:", message=msg)
+                return True
+            else:
+                return False
+
         elif res.status_code >= 400:
             data = res.json()
             try:
@@ -684,13 +695,18 @@ class ImpfterminService():
             "smspin": sms_pin
 
         }
-        res = self.s.post(self.domain + path, json=data, timeout=15)
-        if res.ok:
-            self.log.success("Der Impf-Code wurde erfolgreich angefragt, bitte prüfe deine Mails!")
-            return True
-        else:
-            self.log.error(f"Code-Verifikation fehlgeschlagen: {res.text}")
-            return False
+        while True:
+            res = self.s.post(self.domain + path, json=data, timeout=15)
+            if res.ok:
+                self.log.success("Der Impf-Code wurde erfolgreich angefragt, bitte prüfe deine Mails!")
+                return True
+            elif res.status_code == 429:
+                self.log.error(
+                    "Cookies müssen erneuert werden.")
+                self.renew_cookies_code()
+            else:
+                self.log.error(f"Code-Verifikation fehlgeschlagen: {res.text}")
+                return False
 
     @staticmethod
     def terminsuche(code: str, plz_impfzentren: list, kontakt: dict, PATH: str, check_delay: int = 30):


### PR DESCRIPTION
Cookie wird jetzt erneut bei fehlgeschlagener Code Bestätigung erzeugt. Cookie wird bei 429 Buchung generiert. Schlägt es danach fehl => Selenium Buchung