### PR TITLE
Add ChromeDriver note

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -175,7 +175,9 @@ und anschließend rechts-oben auf "Buchung verwalten" klicken.
 
 * Python 3 (getestet mit Python 3.8 und 3.9)
 * pip (zur Installation der Python-Module, getestet mit pip3)
-* Google Chrome oder Chromium
+* Google Chrome oder Chromium und passende [ChromeDriver Version zur Google Chrome / Chromium Version](https://chromedriver.storage.googleapis.com/index.html)
+  * Habt ihr zum Beispiel Google Chrome in Version 91, braucht ihr die passende Version von dort
+  * Entpacken des Archives, dann nach `tools/chromedriver/chromedriver-mac-intel` (oder Linux/Windows) entpacken   
 
 Die notwendigen Python-Module können mittels pip installiert werden.
 


### PR DESCRIPTION
Chromedriver Beschreibung hinzugefügt - hatte hier immer Fehlermeldungen weil mein Google Chrome auf der neuesten Version 91 ist / war:

```
selenium.common.exceptions.SessionNotCreatedException: 
Message: session not created: This version of ChromeDriver only supports Chrome version 89
Current browser version is 91.XXXX with binary path  XXXXXX
```

Ich pack euch den Hinweis auch an einen anderen Ort wenns dort besser passt, aber dachte den Hinweis kann ein anderer auch brauchen ;-) 


