### PR TITLE
mail kleingeschrieben bei code generierung

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -702,7 +702,7 @@ class ImpfterminService():
         path = "rest/smspin/anforderung"
 
         data = {
-            "email": mail,
+            "email": mail.lower(),
             "leistungsmerkmal": leistungsmerkmal,
             "phone": telefonnummer,
             "plz": plz_impfzentrum


### PR DESCRIPTION
Mails kommen oftmals nicht an, wenn Mail große Buchstaben enthält