### PR TITLE
Fixed colour codes in gui + some spelling mistakes in comments

### DIFF
--- a/tools/gui/qtkontakt.py
+++ b/tools/gui/qtkontakt.py
@@ -78,7 +78,7 @@ class QtKontakt(QtWidgets.QDialog):
             QtWidgets.QMessageBox.critical(self, "Fehlende Daten!", f"Bitte ergänzen!\n\n{error}")
         except AttributeError as error:
             # Parent hat i_kontaktdaten_pfad nicht
-            # Falls der Dialog ein anderer Parent hat soll kein Fehler kommen
+            # Falls der Dialog ein anderer Parent hat, soll kein Fehler kommen
             self.close()
 
     def speicher_einstellungen(self) -> str:
@@ -134,7 +134,7 @@ class QtKontakt(QtWidgets.QDialog):
         telefon = self.i_telefon.text().strip()
         mail = self.i_mail.text().strip()
 
-        # PLZ der Zentren in liste und "strippen"
+        # PLZ der Zentren in Liste und "strippen"
         plz_zentren = plz_zentrum_raw.split(",")
         plz_zentren = [plz.strip() for plz in plz_zentren]
 

--- a/tools/gui/qtterminsuche.py
+++ b/tools/gui/qtterminsuche.py
@@ -33,7 +33,7 @@ class Worker(QObject):
     sobald die Suche beendet wurde, wird ein "fertig" Signal geworfen, welches den Rückgabewert von its übergibt
     """
 
-    # Signal wenn suche abgeschlossen
+    # Signal wenn Suche abgeschlossen
     fertig = pyqtSignal(bool)
 
     def __init__(self, kontaktdaten: dict, zeitspanne: dict, ROOT_PATH: str):
@@ -96,7 +96,7 @@ class QtTerminsuche(QtWidgets.QMainWindow):
         self.zeitspanne = zeitspanne
         self.ROOT_PATH = ROOT_PATH
 
-        # std.out & error umleiten auf das Textfeld
+        # std.out & error auf das Textfeld umleiten
         sys.stdout = EigenerStream(text_schreiben=self.update_ausgabe)
         sys.stderr = EigenerStream(text_schreiben=self.update_ausgabe)
 
@@ -147,7 +147,7 @@ class QtTerminsuche(QtWidgets.QMainWindow):
         # Worker und Thread verbinden
         self.worker.moveToThread(self.thread)
 
-        # Signale setzten
+        # Signale setzen
         self.worker.fertig.connect(self.suche_beendet)
         self.worker.fertig.connect(self.thread.quit)
         self.worker.fertig.connect(self.worker.deleteLater)

--- a/tools/gui/qtterminsuche.py
+++ b/tools/gui/qtterminsuche.py
@@ -162,14 +162,26 @@ class QtTerminsuche(QtWidgets.QMainWindow):
         Args:
             text (str): Text welcher hinzukommen soll
         """
+        # Austausch der Farbcodes / Ascii Zeichen aus der Shell
+        listeCodes = ['\033[95m', '\033[91m', '\033[33m', '\x1b[0m', '\033[94m', '\033[32m', '\033[0m']
+        for farbcode in listeCodes:
+            if farbcode in text:
+                if farbcode == '\033[95m' or farbcode == '\033[91m':
+                    text = f"<div style='color:red'>{text}</div>"
+                elif farbcode == '\033[33m':
+                    text = f"<div style='color:orange'>{text}</div>"
+                elif farbcode == '\x1b[0m':
+                    text = f"<div>{text}</div>"
+                elif farbcode == '\033[94m':
+                    text = f"<div style='color:blue'>{text}</div>"
+                elif farbcode == '\033[32m':
+                    text = f"<div style='color:green'>{text}</div>"
+                text = text.replace(farbcode, '')
 
         cursor = self.console_text_edit.textCursor()
         cursor.movePosition(QtGui.QTextCursor.End)
-        listeCodes = ['\033[95m', '\033[95m', '\033[91m', '\033[33m', '\x1b[0m', '\033[94m', '\033[32m', '\033[0m']
-        for farbcode in listeCodes:
-            if farbcode in text:
-                text = text.replace(farbcode, '')
-        cursor.insertText(str(text))
+        cursor.insertHtml(str(text))
+        cursor.insertText(str("\n"))
         self.console_text_edit.setTextCursor(cursor)
         self.console_text_edit.ensureCursorVisible()
 

--- a/tools/gui/qtterminsuche.py
+++ b/tools/gui/qtterminsuche.py
@@ -165,6 +165,10 @@ class QtTerminsuche(QtWidgets.QMainWindow):
 
         cursor = self.console_text_edit.textCursor()
         cursor.movePosition(QtGui.QTextCursor.End)
+        listeCodes = ['\033[95m', '\033[95m', '\033[91m', '\033[33m', '\x1b[0m', '\033[94m', '\033[32m', '\033[0m']
+        for farbcode in listeCodes:
+            if farbcode in text:
+                text = text.replace(farbcode, '')
         cursor.insertText(str(text))
         self.console_text_edit.setTextCursor(cursor)
         self.console_text_edit.ensureCursorVisible()

--- a/tools/gui/qtzeiten.py
+++ b/tools/gui/qtzeiten.py
@@ -156,7 +156,7 @@ class QtZeiten(QtWidgets.QDialog):
         aktive_wochentage = list()
 
         # Alle Checkboxen der GUI selektieren und durchgehen
-        # BUG: Wenn die reihenfolge im Layout geändert wird, stimmen die Wochentage nicht mehr 0 = Mo ... 6 = So
+        # BUG: Wenn die Reihenfolge im Layout geändert wird, stimmen die Wochentage nicht mehr 0 = Mo ... 6 = So
         checkboxes = self.tage_frame.findChildren(QtWidgets.QCheckBox)
         for num, checkboxe in enumerate(checkboxes, 0):
             if checkboxe.isChecked():


### PR DESCRIPTION
I found the cause of the colour codes in the GUI and replaced them with an empty string. 
This removes any non-displayable characters in the GUI (stdout).

**Before:**
<img width="510" alt="without" src="https://user-images.githubusercontent.com/43381667/120122214-c4c6e380-c1a7-11eb-8ec8-54c1d06adf3b.PNG">

**Afterwards**
<img width="512" alt="neu" src="https://user-images.githubusercontent.com/43381667/120122212-c2648980-c1a7-11eb-90a4-0aae03f8bafd.PNG">



This is my first pull request. I hope I have not made a mistake :)
