### PR TITLE
Add custom properties for weekdays to get python 0 to 6 enumeration f…

### DIFF
--- a/tools/gui/qtzeiten.py
+++ b/tools/gui/qtzeiten.py
@@ -160,7 +160,7 @@ class QtZeiten(QtWidgets.QDialog):
         checkboxes = self.tage_frame.findChildren(QtWidgets.QCheckBox)
         for num, checkboxe in enumerate(checkboxes, 0):
             if checkboxe.isChecked():
-                aktive_wochentage.append(num)
+                aktive_wochentage.append( checkboxe.property("weekday"))
 
         return aktive_wochentage
 

--- a/tools/gui/uhrzeiten.ui
+++ b/tools/gui/uhrzeiten.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>764</width>
+    <width>766</width>
     <height>489</height>
    </rect>
   </property>
@@ -288,6 +288,9 @@
               <property name="checked">
                <bool>true</bool>
               </property>
+              <property name="weekday" stdset="0">
+               <UInt>1</UInt>
+              </property>
              </widget>
             </item>
             <item row="2" column="0" colspan="2">
@@ -297,6 +300,9 @@
               </property>
               <property name="checked">
                <bool>true</bool>
+              </property>
+              <property name="weekday" stdset="0">
+               <UInt>0</UInt>
               </property>
              </widget>
             </item>
@@ -315,6 +321,9 @@
               <property name="checked">
                <bool>true</bool>
               </property>
+              <property name="weekday" stdset="0">
+               <UInt>3</UInt>
+              </property>
              </widget>
             </item>
             <item row="9" column="0" colspan="2">
@@ -324,6 +333,9 @@
               </property>
               <property name="checked">
                <bool>true</bool>
+              </property>
+              <property name="weekday" stdset="0">
+               <UInt>5</UInt>
               </property>
              </widget>
             </item>
@@ -335,6 +347,9 @@
               <property name="checked">
                <bool>true</bool>
               </property>
+              <property name="weekday" stdset="0">
+               <UInt>6</UInt>
+              </property>
              </widget>
             </item>
             <item row="4" column="0" colspan="2">
@@ -344,6 +359,9 @@
               </property>
               <property name="checked">
                <bool>true</bool>
+              </property>
+              <property name="weekday" stdset="0">
+               <UInt>2</UInt>
               </property>
              </widget>
             </item>
@@ -361,6 +379,9 @@
               </property>
               <property name="checked">
                <bool>true</bool>
+              </property>
+              <property name="weekday" stdset="0">
+               <UInt>4</UInt>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
…rom mixed checkobx

At the moment the weekdays are wrong added for example if only Sat and Sun is selected it creates weekday 3,4 which must be 5,6.

Therefore I added a custom property "weekday" to make the ui order of the checkboxes irrelvant and just count on their property 0 = Monday , 6 = Sunday