### PR TITLE
Allow to specify chrome bin via envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,12 +268,11 @@ python3 main.py search -f max-mustermann.json
   
   Dies wird auch z.B. auf NixOS benötigt, um eine eigene chromedriver-Installation zu verwenden.
 
-Für eine bessere Nutzererfahrung erstellen wir verschiedene Distributionen, die ohne Installation von Python direkt ausgeführt werden können. 
-Die Distributionen können im [neusten Release heruntergeladen werden](https://github.com/iamnotturner/vaccipy/releases/latest).
-
 * `VACCIPY_CHROME_BIN`:
   Name oder relativer Pfad der einer alternativen chrome Programmdatei, die du verwenden möchtest.
 
+Für eine bessere Nutzererfahrung erstellen wir verschiedene Distributionen, die ohne Installation von Python direkt ausgeführt werden können. 
+Die Distributionen können im [neusten Release heruntergeladen werden](https://github.com/iamnotturner/vaccipy/releases/latest).
 
 #### [Informationen zu den Distributionen und Shipping findest du hier](https://github.com/iamnotturner/vaccipy/blob/master/docs/distribution.md)
 

--- a/README.md
+++ b/README.md
@@ -271,6 +271,9 @@ python3 main.py search -f max-mustermann.json
 Für eine bessere Nutzererfahrung erstellen wir verschiedene Distributionen, die ohne Installation von Python direkt ausgeführt werden können. 
 Die Distributionen können im [neusten Release heruntergeladen werden](https://github.com/iamnotturner/vaccipy/releases/latest).
 
+* `VACCIPY_CHROME_BIN`:
+  Name oder relativer Pfad der einer alternativen chrome Programmdatei, die du verwenden möchtest.
+
 
 #### [Informationen zu den Distributionen und Shipping findest du hier](https://github.com/iamnotturner/vaccipy/blob/master/docs/distribution.md)
 

--- a/tools/its.py
+++ b/tools/its.py
@@ -191,6 +191,10 @@ class ImpfterminService():
         # Chrome head is only required for the backup booking process.
         # User-Agent is required for headless, because otherwise the server lets us hang.
         chrome_options.add_argument("user-agent=Mozilla/5.0")
+        
+        chromebin_from_env = os.getenv("VACCIPY_CHROME_BIN")
+        if chromebin_from_env:
+            chrome_options.binary_location = os.getenv("VACCIPY_CHROME_BIN")
 
         chrome_options.headless = headless
 


### PR DESCRIPTION
There might be several reason why someone wants to specific the path of the chrome bin (e.g. snap, having a special setup for `chrome` in PATH, ...).

So here a simple pull request to add the option to specify the chrome bin via an envvar.