### PR TITLE
Dynamic setting of the delay between the appointment search

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -37,6 +37,9 @@ class HauptGUI(QtWidgets.QMainWindow):
     ### Layouts ###
     # prozesse_layout
 
+    ### QSpinBox ###
+    # i_interval
+
     def __init__(self, pfad_fenster_layout: str = os.path.join(PATH, "tools/gui/main.ui")):
         """
         Main der GUI Anwendung
@@ -146,12 +149,13 @@ class HauptGUI(QtWidgets.QMainWindow):
             kontaktdaten (dict): kontakdaten aus kontaktdaten.json
             zeitspanne (dict): zeitspanne aus zeitspanne.json
         """
-
+        check_delay = self.i_interval.value()
         code = kontaktdaten["code"]
         terminsuche_prozess = multiprocessing.Process(target=QtTerminsuche.start_suche, name=f"{code}-{self.prozesse_counter}", daemon=True, kwargs={
                                                       "kontaktdaten": kontaktdaten,
                                                       "zeitspanne": zeitspanne,
-                                                      "ROOT_PATH": PATH})
+                                                      "ROOT_PATH": PATH,
+                                                      "check_delay": check_delay})
         try:
             terminsuche_prozess.start()
             if not terminsuche_prozess.is_alive():

--- a/tools/gui/main.ui
+++ b/tools/gui/main.ui
@@ -29,37 +29,7 @@
       <property name="bottomMargin">
        <number>6</number>
       </property>
-      <item row="6" column="0">
-       <widget class="Line" name="line_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Laufende Prozesse:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="9" column="1">
-       <widget class="QPushButton" name="b_termin_suchen">
-        <property name="text">
-         <string>Termin suchen</string>
-        </property>
-        <property name="autoDefault">
-         <bool>false</bool>
-        </property>
-        <property name="default">
-         <bool>true</bool>
-        </property>
-        <property name="flat">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="8" column="0">
+      <item row="10" column="0">
        <spacer name="verticalSpacer">
         <property name="orientation">
          <enum>Qt::Vertical</enum>
@@ -72,28 +42,24 @@
         </property>
        </spacer>
       </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="header_label">
-        <property name="font">
-         <font>
-          <pointsize>14</pointsize>
-         </font>
-        </property>
-        <property name="text">
-         <string>Vaccipy
-
-Willkommen bei der automatischen Terminbuchung
-für den Corona Impfterminservice </string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignCenter</set>
+      <item row="1" column="0" colspan="2">
+       <widget class="Line" name="line">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="9" column="0">
-       <widget class="QPushButton" name="b_code_generieren">
+      <item row="8" column="0">
+       <widget class="Line" name="line_3">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QPushButton" name="b_neue_kontaktdaten">
         <property name="text">
-         <string>Impf-Code generieren</string>
+         <string>Kontaktdaten erstellen</string>
         </property>
        </widget>
       </item>
@@ -155,36 +121,123 @@ für den Corona Impfterminservice </string>
           </item>
          </layout>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="interval_label">
+          <property name="text">
+           <string>Suchinterval:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QGridLayout" name="gridLayout_5">
+          <item row="0" column="1">
+           <widget class="QLabel" name="label_interval_info">
+            <property name="text">
+             <string>(in Sekunden | Min. 30 | Max. 300)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QSpinBox" name="i_interval">
+            <property name="minimumSize">
+             <size>
+              <width>20</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>100</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="minimum">
+             <number>30</number>
+            </property>
+            <property name="maximum">
+             <number>300</number>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
        </layout>
       </item>
-      <item row="3" column="0">
-       <widget class="QPushButton" name="b_neue_kontaktdaten">
-        <property name="text">
-         <string>Kontaktdaten erstellen</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
+      <item row="5" column="1">
        <widget class="QPushButton" name="b_neue_zeitspanne">
         <property name="text">
          <string>Zeitspanne erstellen</string>
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="9" column="0" colspan="2">
        <layout class="QFormLayout" name="prozesse_layout"/>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="6" column="0" colspan="2">
        <widget class="Line" name="line_4">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="Line" name="line">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="header_label">
+        <property name="font">
+         <font>
+          <pointsize>14</pointsize>
+         </font>
+        </property>
+        <property name="text">
+         <string>Vaccipy
+
+Willkommen bei der automatischen Terminbuchung
+für den Corona Impfterminservice </string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0">
+       <widget class="QPushButton" name="b_code_generieren">
+        <property name="text">
+         <string>Impf-Code generieren</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="1">
+       <widget class="QPushButton" name="b_termin_suchen">
+        <property name="text">
+         <string>Termin suchen</string>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+        <property name="default">
+         <bool>true</bool>
+        </property>
+        <property name="flat">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Laufende Prozesse:</string>
         </property>
        </widget>
       </item>
@@ -198,7 +251,7 @@ für den Corona Impfterminservice </string>
      <x>0</x>
      <y>0</y>
      <width>549</width>
-     <height>21</height>
+     <height>18</height>
     </rect>
    </property>
   </widget>

--- a/tools/gui/terminsuche.ui
+++ b/tools/gui/terminsuche.ui
@@ -55,7 +55,7 @@
       </item>
       <item row="2" column="0">
        <layout class="QFormLayout" name="daten_form_layout">
-        <item row="0" column="0">
+        <item row="1" column="0">
          <widget class="QLabel" name="code_name_label">
           <property name="font">
            <font>
@@ -67,7 +67,7 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
+        <item row="1" column="1">
          <widget class="QLabel" name="code_label">
           <property name="font">
            <font>
@@ -79,7 +79,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="vorname_name_label">
           <property name="font">
            <font>
@@ -91,7 +91,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QLabel" name="vorname_label">
           <property name="font">
            <font>
@@ -103,7 +103,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="nachname_name_label">
           <property name="font">
            <font>
@@ -115,7 +115,7 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QLabel" name="nachname_label">
           <property name="font">
            <font>
@@ -124,6 +124,30 @@
           </property>
           <property name="text">
            <string>Mustermann</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="interval_name_label">
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>Interval: </string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="interval_label">
+          <property name="font">
+           <font>
+            <pointsize>12</pointsize>
+           </font>
+          </property>
+          <property name="text">
+           <string>30 Sekunden</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
With @Floskinner 's support, I have added the dynamic setting of the delay between the appointment search to the GUI version.
This PR has probably solved this: #234

**This includes:**

- Setting the delay between 30 and 300 seconds (smaller or larger values aren't possible)
- Passing the time to 'qtterminsuche.py' to display it there
- A different waiting time can be set for each individual search process

<img width="327" alt="start_mit_interval" src="https://user-images.githubusercontent.com/43381667/120247081-99f59180-c272-11eb-90bb-e57bc68ddec7.PNG">

<img width="511" alt="suche_mit_delay" src="https://user-images.githubusercontent.com/43381667/120247084-9cf08200-c272-11eb-9301-66264ca81e1e.PNG">
