### PR TITLE
feat(zeitrahmen): Add new zeitrahmen field for CLI

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ except:
     pass
 
 from tools.its import ImpfterminService
-from tools.kontaktdaten import get_kontaktdaten, validate_kontaktdaten
+from tools.kontaktdaten import decode_wochentag, encode_wochentag, get_kontaktdaten, validate_kontaktdaten, ValidationError
 from tools.utils import create_missing_dirs, remove_prefix
 from tools.exceptions import ValidationError
 
@@ -104,9 +104,48 @@ def update_kontaktdaten_interactive(
             input_kontaktdaten_key(
                 kontaktdaten, ["kontakt", "notificationReceiver"], "> Mail: ")
 
+        if "zeitrahmen" not in kontaktdaten and command == "search":
+            kontaktdaten["zeitrahmen"] = {}
+            if input("> Zeitrahmen festlegen? (y/n): ").lower() != "n":
+                print()
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "einhalten_bei"],
+                    "> Für welchen Impftermin soll der Zeitrahmen gelten? (1/2/beide): ")
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "von_datum"],
+                    "> Von Datum: ")
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "bis_datum"],
+                    "> Bis Datum: ")
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "von_uhrzeit"],
+                    "> Von Uhrzeit: ")
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "bis_uhrzeit"],
+                    "> Bis Uhrzeit: ")
+                print(
+                    "Trage nun die Wochentage ein, an denen die ausgewählten Impftermine liegen dürfen.\n"
+                    "Mehrere Wochentage können durch Komma getrennt werden.\n"
+                    "Beispiel: Mo, Di, Mi, Do, Fr, Sa, So\n"
+                    "Leer lassen, um alle Wochentage auszuwählen.")
+                input_kontaktdaten_key(
+                    kontaktdaten, ["zeitrahmen", "wochentage"],
+                    "> Erlaubte Wochentage: ", parse_wochentage)
+
         json.dump(kontaktdaten, file, ensure_ascii=False, indent=4)
 
     return kontaktdaten
+
+
+def parse_wochentage(string):
+    wochentage = [wt.strip() for wt in string.split(",")]
+    # Leere strings durch "if wt" rausfiltern
+    nums = [decode_wochentag(wt) for wt in wochentage if wt]
+    if nums:
+        nums = sorted(set(nums))
+    else:
+        nums = range(7) # Default: Alle Wochentage auswählen
+    return [encode_wochentag(num) for num in nums]
 
 
 def input_kontaktdaten_key(
@@ -119,8 +158,8 @@ def input_kontaktdaten_key(
         target = target[key]
     key = path[-1]
     while True:
-        target[key] = transformer(input(prompt).strip())
         try:
+            target[key] = transformer(input(prompt).strip())
             validate_kontaktdaten(kontaktdaten)
             break
         except ValidationError as exc:
@@ -148,7 +187,7 @@ def run_search_interactive(kontaktdaten_path, check_delay):
     kontaktdaten = {}
     if os.path.isfile(kontaktdaten_path):
         daten_laden = input(
-            f"> Sollen die vorhandenen Daten aus '{os.path.basename(kontaktdaten_path)}' geladen werden (y/n)?: ").lower()
+            f"> Sollen die vorhandenen Daten aus '{os.path.basename(kontaktdaten_path)}' geladen werden? (y/n): ").lower()
         if daten_laden.lower() != "n":
             kontaktdaten = get_kontaktdaten(kontaktdaten_path)
 
@@ -180,6 +219,8 @@ def run_search(kontaktdaten, check_delay):
         kontakt = kontaktdaten["kontakt"]
         print(
             f"Kontaktdaten wurden geladen für: {kontakt['vorname']} {kontakt['nachname']}\n")
+
+        zeitrahmen = kontaktdaten["zeitrahmen"]
     except KeyError as exc:
         raise ValueError(
             "Kontaktdaten konnten nicht aus 'kontaktdaten.json' geladen werden.\n"
@@ -187,7 +228,7 @@ def run_search(kontaktdaten, check_delay):
             "deine Daten beim Programmstart erneut ein.\n") from exc
 
     ImpfterminService.terminsuche(code=code, plz_impfzentren=plz_impfzentren, kontakt=kontakt,
-                                  check_delay=check_delay, PATH=PATH)
+                                  zeitrahmen=zeitrahmen, check_delay=check_delay, PATH=PATH)
 
 
 def gen_code_interactive(kontaktdaten_path):

--- a/tools/gui/qtterminsuche.py
+++ b/tools/gui/qtterminsuche.py
@@ -61,7 +61,7 @@ class Worker(QObject):
         plz_impfzentren = self.kontaktdaten["plz_impfzentren"]
 
         erfolgreich = ImpfterminService.terminsuche(code=code, plz_impfzentren=plz_impfzentren, kontakt=kontakt,
-                                                    PATH=self.ROOT_PATH, check_delay=self.check_delay, zeitspanne=self.zeitspanne)
+                                                    PATH=self.ROOT_PATH, check_delay=self.check_delay, zeitrahmen=self.zeitspanne)
 
         self.fertig.emit(erfolgreich)
 

--- a/tools/gui/qtzeiten.py
+++ b/tools/gui/qtzeiten.py
@@ -131,18 +131,16 @@ class QtZeiten(QtWidgets.QDialog):
         termine = self.__get_aktive_termine()
         start_datum = self.__get_start_datum()
 
-        zeitspanne = {
-            "wochentage": aktive_wochentage,
-            "startzeit": uhrzeiten["startzeit"],
-            "endzeit": uhrzeiten["endzeit"],
-            "einhalten_bei": termine,
-            "startdatum": {
-                "jahr": start_datum.year(),
-                "monat": start_datum.month(),
-                "tag": start_datum.day()
-            },
-        }
-        return zeitspanne
+        if termine:
+            return {
+                "von_datum": f"{start_datum.day()}.{start_datum.month()}.{start_datum.year()}",
+                "von_uhrzeit": f"{uhrzeiten['startzeit']['h']}:{uhrzeiten['startzeit']['m']}",
+                "bis_uhrzeit": f"{uhrzeiten['endzeit']['h']}:{uhrzeiten['endzeit']['m']}",
+                "wochentage": aktive_wochentage,
+                "einhalten_bei": "beide" if len(termine) > 1 else str(termine[0]),
+            }
+        else:
+            return {}
 
     def __get_aktive_wochentage(self) -> list:
         """

--- a/tools/gui/uhrzeiten.ui
+++ b/tools/gui/uhrzeiten.ui
@@ -289,7 +289,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>1</UInt>
+               <string>Di</string>
               </property>
              </widget>
             </item>
@@ -302,7 +302,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>0</UInt>
+               <string>Mo</string>
               </property>
              </widget>
             </item>
@@ -322,7 +322,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>3</UInt>
+               <string>Do</string>
               </property>
              </widget>
             </item>
@@ -335,7 +335,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>5</UInt>
+               <string>Sa</string>
               </property>
              </widget>
             </item>
@@ -348,7 +348,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>6</UInt>
+               <string>So</string>
               </property>
              </widget>
             </item>
@@ -361,7 +361,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>2</UInt>
+               <string>Mi</string>
               </property>
              </widget>
             </item>
@@ -381,7 +381,7 @@
                <bool>true</bool>
               </property>
               <property name="weekday" stdset="0">
-               <UInt>4</UInt>
+               <string>Fr</string>
               </property>
              </widget>
             </item>

--- a/tools/kontaktdaten.py
+++ b/tools/kontaktdaten.py
@@ -1,3 +1,5 @@
+import calendar
+import datetime
 import json
 import os
 import re
@@ -7,6 +9,21 @@ from tools.exceptions import ValidationError, MissingValuesError
 from tools import Modus
 
 
+WOCHENTAG_ABBRS = ["Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"]
+WOCHENTAG_NAMES = [
+    "Montag",
+    "Dienstag",
+    "Mittwoch",
+    "Donnerstag",
+    "Freitag",
+    "Samstag",
+    "Sonntag"]
+
+
+class ValidationError(Exception):
+    pass
+
+
 def get_kontaktdaten(filepath: str):
     """
     Lade Kontaktdaten aus Datei.
@@ -14,7 +31,7 @@ def get_kontaktdaten(filepath: str):
     :param filepath: Pfad zur JSON-Datei mit Kontaktdaten.
     :return: Dictionary mit Kontaktdaten
 
-    :raise: ValidationError: Wird geworfen wenn eine Datei ungültige Values besitzt
+    :raise ValidationError: Falls Validierung der gelesenen Kontaktdaten fehlschlägt
     """
 
     try:
@@ -65,10 +82,12 @@ def check_kontaktdaten(kontaktdaten: dict, mode: Modus):
 
 def validate_kontaktdaten(kontaktdaten: dict):
     """
-    Erhebt ValidationError, falls Kontaktdaten ungültig sind.
-    Leere Werte werden als Fehler angesehen
+    Validiert Kontaktdaten.
+    Leere Werte werden als Fehler angesehen.
 
-    :param kontaktdaten: Dictionary mit Kontaktdaten
+    :raise ValidationError: Typ ist nicht dict
+    :raise ValidationError: Einer der enthaltenen Keys ist unbekannt
+    :raise ValidationError: Eine der enthaltenen Values ist ungültig
     """
 
     if not isinstance(kontaktdaten, dict):
@@ -82,6 +101,8 @@ def validate_kontaktdaten(kontaktdaten: dict):
                 validate_plz_impfzentren(value)
             elif key == "kontakt":
                 validate_kontakt(value)
+            elif key == "zeitrahmen":
+                validate_zeitrahmen(value)
             else:
                 raise ValidationError(f"Nicht unterstützter Key")
         except ValidationError as exc:
@@ -149,16 +170,12 @@ def validate_plz(plz: str):
 
 def validate_kontakt(kontakt: dict):
     """
-    Validiert die Kontaktdaten auf Plausibilität.
+    Validiert "kontakt"-Key aus Kontaktdaten.
     Leere Werte werden als Fehler angesehen.
-    Wenn ein Key zu viel ist, wird dies nicht als Fehler erachtet
 
-    Args:
-        kontakt (dict): Kontakt Daten aus der JSON
-
-    Raises:
-        ValidationError: Kontakt ist kein dict
-        ValidationError: Einer der Values ist ungültig
+    :raise ValidationError: Typ ist nicht dict
+    :raise ValidationError: Einer der enthaltenen Keys ist unbekannt
+    :raise ValidationError: Eine der enthaltenen Values ist ungültig
     """
 
     if not isinstance(kontakt, dict):
@@ -235,22 +252,156 @@ def validate_hausnummer(hausnummer: str):
 
 def validate_email(email: str):
     """
-    Validiert eMail auf: Typ, gültigkeit, "leer"
+    Validiert eine E-Mail-Adresse.
 
-    Args:
-        email (str): email
-
-    Raises:
-        ValidationError: Typ ist nicht str
-        ValidationError: Zeichenkette enhält kein @
-        ValidationError: Zeichenkette ist leer
+    :raise ValidationError: Typ ist nicht str
+    :raise ValidationError: Zeichenkette ist offensichtlich keine gültige E-Mail-Adresse
     """
 
     if not isinstance(email, str):
         raise ValidationError("Muss eine Zeichenkette sein")
 
+    # https://stackoverflow.com/a/14485817/7350842
     if '@' not in parseaddr(email)[1]:
         raise ValidationError(f"Ungültige E-Mail-Adresse {json.dumps(email)}")
 
-    if email.strip() == "":
-        raise ValidationError("E-Mail-Adresse ist leer")
+
+def validate_zeitrahmen(zeitrahmen: dict):
+    """
+    Validiert "zeitrahmen"-Key aus Kontaktdaten.
+
+    :raise ValidationError: Typ ist nicht dict
+    :raise ValidationError: Einer der enthaltenen Keys ist unbekannt
+    :raise ValidationError: Eine der enthaltenen Values ist ungültig
+    """
+
+    if not isinstance(zeitrahmen, dict):
+        raise ValidationError("Muss ein Dictionary sein")
+
+    if zeitrahmen == {}:
+        return
+
+    # Ein ganz leerer Zeitrahmen ist zulässig (s.o.), aber ansonsten muss der
+    # Key "einhalten_bei" vorhanden sein.
+    if "einhalten_bei" not in zeitrahmen:
+        raise ValidationError(
+            'Ein gesetzter Zeitrahmen braucht zwingend den Key "einhalten_bei"')
+
+    for key, value in zeitrahmen.items():
+        try:
+            if key in ["von_datum", "bis_datum"]:
+                validate_datum(value)
+            elif key in ["von_uhrzeit", "bis_uhrzeit"]:
+                validate_uhrzeit(value)
+            elif key == "wochentage":
+                if not isinstance(value, list):
+                    raise ValidationError("Muss eine Liste sein")
+
+                for weekday in value:
+                    validate_wochentag(weekday)
+            elif key == "einhalten_bei":
+                validate_einhalten_bei(value)
+            else:
+                raise ValidationError(f"Nicht unterstützter Key")
+        except ValidationError as exc:
+            raise ValidationError(
+                f"Ungültiger Key {json.dumps(key)}:\n{str(exc)}")
+
+
+def validate_datum(date: str):
+    """
+    Validiert ein Datum im erwarteten Format "30.11.1970".
+
+    :raise ValidationError: Typ ist nicht str
+    :raise ValidationError: Zeichenkette hat nicht das richtige Format
+    """
+
+    if not isinstance(date, str):
+        raise ValidationError("Muss eine Zeichenkette sein")
+
+    try:
+        datetime.datetime.strptime(date, "%d.%m.%Y")
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+
+def validate_uhrzeit(time: str):
+    """
+    Validiert eine Uhrzeit im erwarteten Format "14:35".
+
+    :raise ValidationError: Typ ist nicht str
+    :raise ValidationError: Zeichenkette hat nicht das richtige Format
+    """
+
+    if not isinstance(time, str):
+        raise ValidationError("Muss eine Zeichenkette sein")
+
+    try:
+        datetime.datetime.strptime(time, "%H:%M")
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+
+def validate_wochentag(wochentag: str):
+    """
+    Validiert einen Wochentag.
+    Erlaubt sind "Montag" bis "Sonntag".
+    Es sind auch Präfixe vom Wochentag-Namen zulässig, solange diese mindestens
+    zwei Zeichen lang sind, z. B. "Mo", "Mon", "Mont", usw.
+
+    :raise ValidationError: Typ ist nicht str
+    :raise ValidationError: Zeichenkette hat nicht das richtige Format
+    """
+
+    if not isinstance(wochentag, str):
+        raise ValidationError("Muss eine Zeichenkette sein")
+
+    try:
+        decode_wochentag(wochentag)
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+
+
+def validate_einhalten_bei(einhalten_bei: str):
+    """
+    Validiert "zeitrahmen"."einhalten_bei"-Key aus Kontaktdaten.
+    Erlaubte Parameter sind: "1", "2", "beide"
+
+    :raise ValidationError: Parameter ist nicht erlaubt (s.o.)
+    """
+
+    if not isinstance(einhalten_bei, str):
+        raise ValidationError("Muss eine Zeichenkette sein")
+
+    if einhalten_bei not in ["1", "2", "beide"]:
+        raise ValidationError('Erlaubt sind: "1", "2", "beide"')
+
+
+def decode_wochentag(wochentag: str):
+    """
+    Wandelt einen Wochentag-Namen in seinen Index um, d. h. "Montag" -> 0,
+    "Dienstag" -> 1, usw.
+    Es sind auch Präfixe vom Wochentag-Namen zulässig, solange diese mindestens
+    zwei Zeichen lang sind, z. B. "Mo", "Mon", "Mont", usw.
+    """
+
+    num = None
+    if len(wochentag) >= 2:
+        num = next((i for i, wt in enumerate(WOCHENTAG_NAMES)
+                    if wt.lower().startswith(wochentag.lower())), None)
+    if num is None:
+        raise ValueError(
+            f"Ungültiger Wochentag: {json.dumps(wochentag)}"
+            ' - erlaubt sind: "Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"')
+    return num
+
+
+def encode_wochentag(num: int):
+    """
+    Wandelt einen Wochentag-Index in den zugehörigen Namen um.
+    Es werden nur die ersten zwei Zeichen vom Namen zurückgegeben, d. h.
+    0 -> "Mo", 1 -> "Di", usw.
+    Dies ist kompatibel mit decode_wochentag, wo zwei Zeichen genügen.
+    """
+
+    return WOCHENTAG_ABBRS[num]


### PR DESCRIPTION
In ImpfterminService, rename `zeitspanne` to `zeitrahmen` and change its format to be more user-friendly. Also, make it possible to configure this `zeitrahmen` via the `.zeitrahmen` field of `kontaktdaten.json` and via the CLI. As before, one can construct a fully-featured `kontaktdaten.json` via the CLI.
    
This commit also adapts the GUI to pass the new format to the ImpfterminService. However, it will need further changes to migrate from `zeitspanne.json` to `kontaktdaten.json`, so that GUI and CLI use the same storage format.

**Note: GUI is currently untested**, cause I didn't get it to run, yet.