### PR TITLE
[Feature]: Impfzentren können direkt in der GUI ausgewählt werden

### DIFF
--- a/tools/gui/impfzentren.ui
+++ b/tools/gui/impfzentren.ui
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="windowModality">
+   <enum>Qt::NonModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>863</width>
+    <height>608</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>vaccipy - Impfzentren wählen</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="6" column="0">
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok|QDialogButtonBox::Reset</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="font">
+        <font>
+         <pointsize>14</pointsize>
+        </font>
+       </property>
+       <property name="text">
+        <string>Wähle die Impfzentren - nicht Gruppenübergreifend</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QScrollArea" name="scrollArea">
+       <property name="widgetResizable">
+        <bool>true</bool>
+       </property>
+       <widget class="QWidget" name="scrollAreaWidgetContents">
+        <property name="geometry">
+         <rect>
+          <x>0</x>
+          <y>0</y>
+          <width>841</width>
+          <height>528</height>
+         </rect>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_3">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="impfzentren_grid_layout">
+           <property name="verticalSpacing">
+            <number>12</number>
+           </property>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/tools/gui/kontaktdaten.ui
+++ b/tools/gui/kontaktdaten.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>715</width>
+    <width>727</width>
     <height>428</height>
    </rect>
   </property>
@@ -29,6 +29,41 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="subheader_label">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Gebe Bitte deine Persöhnliche Daten ein</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
    <item row="3" column="0">
     <layout class="QGridLayout" name="main_grid">
      <item row="1" column="1">
@@ -49,22 +84,6 @@
         <widget class="QLabel" name="plz_impfzent_label">
          <property name="text">
           <string>PLZ's der Impfzentren:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="i_plz_impfzentren">
-         <property name="inputMask">
-          <string/>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="placeholderText">
-          <string>Beispiel: 68163, 69124, 69469</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
          </property>
         </widget>
        </item>
@@ -314,46 +333,38 @@
          </property>
         </widget>
        </item>
+       <item row="0" column="1">
+        <layout class="QGridLayout" name="plz_zentren_grid_layout">
+         <item row="0" column="0">
+          <widget class="QLineEdit" name="i_plz_impfzentren">
+           <property name="inputMask">
+            <string/>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="placeholderText">
+            <string>Beispiel: 68163, 69124, 69469</string>
+           </property>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QPushButton" name="b_impfzentren_waehlen">
+           <property name="text">
+            <string>Impfzentren auswählen</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="subheader_label">
-     <property name="font">
-      <font>
-       <pointsize>12</pointsize>
-      </font>
-     </property>
-     <property name="text">
-      <string>Gebe Bitte deine Persöhnliche Daten ein</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="2" column="0">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Reset|QDialogButtonBox::Save</set>
@@ -363,7 +374,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>i_plz_impfzentren</tabstop>
   <tabstop>i_code_impfzentren</tabstop>
   <tabstop>i_anrede_combo_box</tabstop>
   <tabstop>i_vorname</tabstop>

--- a/tools/gui/qtimpfzentren.py
+++ b/tools/gui/qtimpfzentren.py
@@ -1,0 +1,235 @@
+import os
+from PyQt5 import QtWidgets, uic, QtGui, QtCore
+from tools.utils import get_grouped_impfzentren
+
+
+PATH = os.path.dirname(os.path.realpath(__file__))
+
+
+class QtImpfzentren(QtWidgets.QDialog):
+    # Folgende Widgets stehen zur Verfügung:
+
+    ### Layout ###
+    # impfzentren_grid_layout
+
+    ### ButtonBox ###
+    # buttonBox
+    # Ok
+    # Cancel
+
+    ### QWidget ###
+    # scrollAreaWidgetContents
+
+    # Signal welches geworfen wird, wenn man auf Apply drückt
+    # Gibt einen String mit allen aktiven PLZ zurück
+    update_impfzentren_plz = QtCore.pyqtSignal(str)
+
+    def __init__(self, parent: QtWidgets.QWidget, pfad_fenster_layout=os.path.join(PATH, "impfzentren.ui")):
+        super().__init__(parent=parent)
+
+        # Laden der .ui Datei und init config
+        uic.loadUi(pfad_fenster_layout, self)
+
+        # ButtonBox Event verknüpfen
+        self.buttonBox.clicked.connect(self.__button_box_clicked)
+
+        self.init_layout()
+
+    def init_layout(self):
+        """
+        Erstellt dynamisch die Gruppen, CheckBoxes und Labels
+        """
+
+        impfzentren: dict = get_grouped_impfzentren()
+
+        for gruppe, zentren in impfzentren.items():
+            row = self.impfzentren_grid_layout.rowCount()
+            gruppen_font = QtGui.QFont()
+            gruppen_font.setPointSize(12)
+            gruppen_font.setUnderline(True)
+
+            horizontale_linie = self.get_horizontale_linie()
+            gruppen_label = QtWidgets.QLabel(f"{gruppe} - {zentren[0]['Bundesland']}")
+            gruppen_label.setFont(gruppen_font)
+
+            self.impfzentren_grid_layout.addWidget(horizontale_linie, row, 0, 1, 1)
+            self.impfzentren_grid_layout.addWidget(gruppen_label, row+1, 0, 1, 1)
+
+            form_layout = QtWidgets.QFormLayout()
+            form_layout.setVerticalSpacing(15)
+            form_layout.setHorizontalSpacing(10)
+            for zentrum in zentren:
+                checkbox, info_grid = self.get_zentrum_widgets(gruppe, zentrum)
+
+                # Skippen, wenn es keine PLZ gibt (bsp. Gruppe 10)
+                if checkbox.property("PLZ"):
+                    form_layout.addRow(checkbox, info_grid)
+
+            self.impfzentren_grid_layout.addLayout(form_layout, row+2, 0, 1, 1)
+
+    def get_horizontale_linie(self) -> QtWidgets.QFrame:
+        """
+        Erstellt eine Horizontal Linie
+
+        Returns:
+            QtWidgets.QFrame: [description]
+        """
+
+        linie = QtWidgets.QFrame()
+        linie.setMinimumWidth(1)
+        linie.setFixedHeight(20)
+        linie.setFrameShape(QtWidgets.QFrame.HLine)
+        linie.setFrameShadow(QtWidgets.QFrame.Sunken)
+        linie.setSizePolicy(QtWidgets.QSizePolicy.Preferred, QtWidgets.QSizePolicy.Minimum)
+
+        return linie
+
+    def get_zentrum_widgets(self, gruppe: str, zentrum: dict) -> list[QtWidgets.QCheckBox, QtWidgets.QGridLayout]:
+        """
+        Erstellt ein Widget Paket für die Checkbox mit entsprechendem Layout welches die Labels enhalten
+
+        Args:
+            gruppe (str): Gruppe welcher der Button zugeordnet werden soll
+            zentrum (dict): Zentrum Daten
+
+        Returns:
+            list[QtWidgets.QCheckBox, QtWidgets.QGridLayout]: Checkbox mit den propertys PLZ und GRUPPE
+                                                              Layout mit entsprechenden Labels und beschriftungen
+        """
+
+        # Form und Layout erstellen
+        info_form_Layout = QtWidgets.QGridLayout()
+        font_ort = QtGui.QFont()
+        font_ort.setBold(True)
+
+        # Checkbox erstellen und konfigurieren
+        checkbox = QtWidgets.QCheckBox()
+        checkbox.setText(zentrum["PLZ"])
+        checkbox.setProperty("PLZ", zentrum["PLZ"])
+        checkbox.setProperty("GRUPPE", gruppe)
+        checkbox.stateChanged.connect(lambda: self.checkbox_clicked(checkbox))
+
+        # Label beschriften
+        ort_zentrum_label = QtWidgets.QLabel(zentrum["Ort"])
+        name_zentrum_label = QtWidgets.QLabel(zentrum["Zentrumsname"])
+
+        # Extra Font für den Ort Label
+        ort_zentrum_label.setFont(font_ort)
+
+        # Labels dem GridLayout hinzufügen
+        info_form_Layout.addWidget(ort_zentrum_label)
+        info_form_Layout.addWidget(name_zentrum_label)
+
+        return checkbox, info_form_Layout
+
+    def disable_plz_checkboxes(self, gruppe: str):
+        """
+        Deaktiviert alle Checkboxen außer der übergebenen Gruppe
+
+        Args:
+            gruppe (str): Gruppenname welcher nicht deaktiviert wird
+        """
+
+        all_checkboxes = self.scrollAreaWidgetContents.findChildren(QtWidgets.QCheckBox)
+
+        for checkbox in all_checkboxes:
+            if checkbox.property("GRUPPE") == gruppe:
+                checkbox.setEnabled(True)
+            else:
+                checkbox.setDisabled(True)
+
+    def enable_all_checkboxes(self):
+        """
+        Aktiviert alle Checkboxen
+        """
+
+        all_checkboxes = self.scrollAreaWidgetContents.findChildren(QtWidgets.QCheckBox)
+
+        for checkbox in all_checkboxes:
+            checkbox.setEnabled(True)
+
+    def checkbox_clicked(self, checkbox: QtWidgets.QCheckBox):
+        """
+        Funktion welche nach dem Klicken auf eine Checkbox ausgeführt werden soll
+        Aktiviert / Deaktiviert alle andern Checkboxen in einer anderen Gruppe
+
+        Args:
+            checkbox (QtWidgets.QCheckBox): chebox welche geklickt wurde
+        """
+
+        gruppe = checkbox.property("GRUPPE")
+
+        if self.get_all_checked_boxes():
+            self.disable_plz_checkboxes(gruppe)
+        else:
+            self.enable_all_checkboxes()
+
+    def bestaetigt(self):
+        """
+        Die Aktiven PLZ werden in dem Hauptfenster eingetragen
+        Emit von update_impfzentren_plz
+        """
+
+        plz_string = ",".join(self.get_all_plz_from_checked_boxes())
+        self.update_impfzentren_plz.emit(plz_string)
+
+    def get_all_plz_from_checked_boxes(self) -> list[str]:
+        """
+        Liste mit allen aktiven PLZ
+
+        Returns:
+            list[str]: Aktive PLZ
+        """
+
+        plzs = list()
+        checked_boxes = self.get_all_checked_boxes()
+
+        for checkbox in checked_boxes:
+            plzs.append(checkbox.property("PLZ"))
+
+        return plzs
+
+    def __button_box_clicked(self, button: QtWidgets.QPushButton):
+        """
+        Zuweisung der einzelnen Funktionen der Buttons in der ButtonBox
+
+        Args:
+            button (PyQt5.QtWidgets.QPushButton): Button welcher gedrückt wurde
+        """
+
+        clicked_button = self.buttonBox.standardButton(button)
+        if clicked_button == QtWidgets.QDialogButtonBox.Ok:
+            self.bestaetigt()
+        if clicked_button == QtWidgets.QDialogButtonBox.Reset:
+            self.reset()
+        elif clicked_button == QtWidgets.QDialogButtonBox.Cancel:
+            self.close()
+
+    def get_all_checked_boxes(self) -> list[QtWidgets.QCheckBox]:
+        """
+        Gibt alle checked checkboxes zurück
+
+        Returns:
+            list[QtWidgets.QCheckBox]: Liste mit Checkboxen
+        """
+
+        all_checkboxes = self.scrollAreaWidgetContents.findChildren(QtWidgets.QCheckBox)
+        checked_boxes = list()
+
+        for checkbox in all_checkboxes:
+            if checkbox.isChecked():
+                checked_boxes.append(checkbox)
+        return checked_boxes
+
+    def reset(self):
+        """
+        Alle Checkboxen "uncheck"
+        Alle Checkboxen aktivieren
+        """
+
+        all_checkboxes = self.scrollAreaWidgetContents.findChildren(QtWidgets.QCheckBox)
+
+        for checkbox in all_checkboxes:
+            checkbox.setChecked(False)
+
+        self.enable_all_checkboxes()

--- a/tools/gui/qtkontakt.py
+++ b/tools/gui/qtkontakt.py
@@ -5,6 +5,7 @@ from PyQt5.QtCore import QTime
 from PyQt5.QtGui import QIcon
 
 from tools.gui import *
+from tools.gui.qtimpfzentren import QtImpfzentren
 
 # Folgende Widgets stehen zur Verfügung:
 
@@ -32,6 +33,9 @@ from tools.gui import *
 ### Layouts ###
 # kontakdaten_layout
 
+### Buttons ###
+# b_impfzentren_waehlen
+
 PATH = os.path.dirname(os.path.realpath(__file__))
 
 
@@ -42,13 +46,16 @@ class QtKontakt(QtWidgets.QDialog):
         self.standard_speicherpfad = standard_speicherpfad
         self.modus = modus
 
-        # Laden der .ui Datei
+        # Laden der .ui Datei und init config
         uic.loadUi(pfad_fenster_layout, self)
         self.setWindowIcon(QIcon(os.path.join(ROOT_PATH, "images/spritze.ico")))
         self.setup()
 
-        # Funktionen für Buttonbox zuweisen
+        # Funktionen der ButtonBox zuordnen
         self.buttonBox.clicked.connect(self.__button_clicked)
+
+        # Funktion vom Button zuordnen
+        self.b_impfzentren_waehlen.clicked.connect(self.__open_impfzentren)
 
     def setup(self):
         if self.modus == Modus.TERMIN_SUCHEN:
@@ -98,7 +105,7 @@ class QtKontakt(QtWidgets.QDialog):
         speichern(speicherpfad, data)
         return speicherpfad
 
-    def __button_clicked(self, button):
+    def __button_clicked(self, button: QtWidgets.QPushButton):
         """
         Zuweisung der einzelnen Funktionen der Buttons in der ButtonBox
 
@@ -113,6 +120,26 @@ class QtKontakt(QtWidgets.QDialog):
             self.__reset()
         elif clicked_button == QtWidgets.QDialogButtonBox.Cancel:
             self.close()
+
+    def __open_impfzentren(self):
+        """
+        Öffnet den Dialog um PLZ auszuwählen
+        """
+
+        impfzentren_dialog = QtImpfzentren(self)
+        impfzentren_dialog.update_impfzentren_plz.connect(self.__set_impzentren_plz)
+        impfzentren_dialog.show()
+        impfzentren_dialog.exec_()
+
+    def __set_impzentren_plz(self, plz: str):
+        """
+        Übergebener Text wird in das QLineEdit i_plz_impfzentren geschrieben
+
+        Args:
+            plz (str): Kommagetrennte PLZ der Impfzentren in einer Gruppe
+        """
+
+        self.i_plz_impfzentren.setText(plz)
 
     def __get_alle_werte(self) -> dict:
         """
@@ -185,11 +212,3 @@ class QtKontakt(QtWidgets.QDialog):
 
         # Telefon wieder mit Prefix befüllen
         self.i_telefon.setText("+49")
-
-
-# Zum schnellen einzeltesten
-if __name__ == "__main__":
-    app = QtWidgets.QApplication(list())
-    window = QtKontakt("./kontaktdaten.json")
-    window.show()
-    app.exec_()

--- a/tools/gui/qtzeiten.py
+++ b/tools/gui/qtzeiten.py
@@ -156,11 +156,10 @@ class QtZeiten(QtWidgets.QDialog):
         aktive_wochentage = list()
 
         # Alle Checkboxen der GUI selektieren und durchgehen
-        # BUG: Wenn die reihenfolge im Layout geändert wird, stimmen die Wochentage nicht mehr 0 = Mo ... 6 = So
         checkboxes = self.tage_frame.findChildren(QtWidgets.QCheckBox)
         for num, checkboxe in enumerate(checkboxes, 0):
             if checkboxe.isChecked():
-                aktive_wochentage.append( checkboxe.property("weekday"))
+                aktive_wochentage.append(checkboxe.property("weekday"))
 
         return aktive_wochentage
 
@@ -236,10 +235,3 @@ class QtZeiten(QtWidgets.QDialog):
                     widget.setTime(QTime(23, 59))
             elif isinstance(widget, QtWidgets.QFrame):
                 self.__reset(widget.children())
-
-
-if __name__ == "__main__":
-    app = QtWidgets.QApplication(list())
-    window = QtZeiten(".\\zeitspanne.json")
-    window.show()
-    app.exec_()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,5 +1,6 @@
 import time
 import traceback
+import requests
 from pathlib import Path
 
 from threading import Thread
@@ -112,4 +113,32 @@ def create_missing_dirs():
     """
     Path("./data").mkdir(parents=True, exist_ok=True)
 
-        
+
+def get_grouped_impfzentren() -> dict:
+    """
+    Gibt ein dict mit allen Impfzentren Grupiert nach den gültigen Codes
+
+    Returns:
+        dict: Informationen über die Impfzentren
+    """
+
+    url = "https://www.impfterminservice.de/assets/static/impfzentren.json"
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/89.0.4389.82 Safari/537.36',
+    }
+    impfzentren_sortiert = {}
+    res = requests.get(url, timeout=15, headers=headers)
+    if res.ok:
+        for bundesland, impfzentren in res.json().items():
+            for impfzentrum in impfzentren:
+                url = impfzentrum["URL"]
+                # liste von impfzentren_sortiert oder leere liste
+                impfzentren_gruppiert = impfzentren_sortiert.get(url, [])
+                # impfzentrum zur liste hinzufügen
+                impfzentren_gruppiert.append(impfzentrum)
+                # liste in dict abspeichern
+                impfzentren_sortiert[url] = impfzentren_gruppiert
+    result = {}
+    for gruppe, impfzentren in enumerate(impfzentren_sortiert.values(), start=1):
+        result[f"Gruppe {gruppe}"] = impfzentren
+    return result


### PR DESCRIPTION
New Feature
-
Man muss nun nicht mehr die ganzen PLZs der Impfzentren manuel raussuchen + sieht direkt welche Impfzentren gruppiert sind
- Die Impfzentren können nun direkt in der GUI ausgewählt werden
- Alle Impfzentren werden dynamisch hinzugefügt ( immer up-to-date )
- Nur die PLZs der gleichen Gruppe können hinzugefügt werden
- Neue Funktion in der `utils.py` - `get_grouped_impfzentren` - Danke an @iamnotturner  für den Code, hat mein Leben sehr erleichtert!

Bilder
-
Neuer Button:
![vaccipy - Kontaktdaten0](https://user-images.githubusercontent.com/58706771/120392536-eacbbf80-c330-11eb-86c7-8c8415dc7469.png)

---------

Übersicht aller Zentren:
![vaccipy - Kontaktdaten1](https://user-images.githubusercontent.com/58706771/120392540-eb645600-c330-11eb-8d8e-cd64e8640c42.png)

---------

Wählt meine eine Gruppe aus, sind die anderen gesperrt
![vaccipy - Kontaktdaten2](https://user-images.githubusercontent.com/58706771/120392542-ebfcec80-c330-11eb-872f-20b70a41d9e4.png)

---------

Importieren in das Eingabefeld
![vaccipy - Kontaktdaten3](https://user-images.githubusercontent.com/58706771/120392544-ebfcec80-c330-11eb-8ea8-88738de6e1e5.png)

Tests
-
Tests waren alle erfolgreich und kann direkt ge-merged werden :)