### PR TITLE
Fix(kontakdaten - GUI): Speichern von Kontaktdaten nicht möglich da ein Key Fehlt

### DIFF
--- a/tools/kontaktdaten.py
+++ b/tools/kontaktdaten.py
@@ -65,7 +65,9 @@ def check_kontaktdaten(kontaktdaten: dict, mode: Modus):
             kontaktdaten["kontakt"]["hausnummer"]
             kontaktdaten["kontakt"]["plz"]
             kontaktdaten["kontakt"]["ort"]
-            kontaktdaten["zeitspanne"]
+
+            #BUG: Erstmal auskommentiert lassen, bis die GUI entsprechend angepasst wurde
+            #kontaktdaten["zeitspanne"]
             # Subkeys von "zeitspanne" brauchen nicht gecheckt werden, da
             # `kontaktdaten["zeitspanne"] == {}` zulässig ist.
 


### PR DESCRIPTION
Fix for #268 

Die GUI ist noch nicht vollständig auf die neue Zeitspanne umgestellt, daher fehlt immer der Key `zeitspanne` in dem `kontaktdaten.json`

Deshalb vorübergehend die Überprüfung auf das Feld auskommentiert