### PR TITLE
Show appointments outside the time frame as a warning

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -597,12 +597,18 @@ class ImpfterminService():
                     if tp not in terminpaare_angenommen
                 ]
                 for tp_abgelehnt in terminpaare_abgelehnt:
-                    self.log.info(
+                    self.log.warn(
                         "Termin gefunden - jedoch nicht im entsprechenden Zeitraum")
+                    self.log.info('-' * 50)
+                    impfzentrum = self.verfuegbare_impfzentren.get(plz)
+                    zentrumsname = impfzentrum.get('Zentrumsname').strip()
+                    ort = impfzentrum.get('Ort')
+                    self.log.warn(f"'{zentrumsname}' in {plz} {ort}")
                     for num, termin in enumerate(tp_abgelehnt, 1):
                         ts = datetime.fromtimestamp(termin["begin"] / 1000).strftime(
                             '%d.%m.%Y um %H:%M Uhr')
-                        self.log.info(f"{num}. Termin: {ts}")
+                        self.log.warn(f"{num}. Termin: {ts}")
+                    self.log.info('-' * 50)
                 if terminpaare_angenommen:
                     # Auswahl des erstbesten Terminpaares
                     self.terminpaar = choice(terminpaare_angenommen)

--- a/tools/its.py
+++ b/tools/its.py
@@ -598,7 +598,7 @@ class ImpfterminService():
                 ]
                 for tp_abgelehnt in terminpaare_abgelehnt:
                     self.log.warn(
-                        "Termin gefunden - jedoch nicht im entsprechenden Zeitraum")
+                        "Termin gefunden - jedoch nicht im entsprechenden Zeitraum:")
                     self.log.info('-' * 50)
                     impfzentrum = self.verfuegbare_impfzentren.get(plz)
                     zentrumsname = impfzentrum.get('Zentrumsname').strip()


### PR DESCRIPTION
Appointments outside the time frame are now displayed as a warning. 
This makes it easier to notice if you want to book the appointment manually for another person, for example.
I have also added dividing lines to make them more visually separable.

<img width="605" alt="python_x2g4hX4YWJ" src="https://user-images.githubusercontent.com/43381667/120643363-5cf9ec80-c476-11eb-86f6-ec2a0d9a0c7d.png">
