### PR TITLE
fix(gui version): Absturz wenn version.txt nicht vorhanden

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -103,7 +103,7 @@ class HauptGUI(QtWidgets.QMainWindow):
         try:
             self.setWindowTitle('vaccipy ' + get_current_version())
         except Exception as error:
-            #Standardwert ist vaccipy
+            self.setWindowTitle('vaccipy')
             pass
 
         # Meldung falls alte Daten von alter Version

--- a/gui.py
+++ b/gui.py
@@ -100,7 +100,11 @@ class HauptGUI(QtWidgets.QMainWindow):
         ### GUI ###
         uic.loadUi(pfad_fenster_layout, self)
         self.setWindowIcon(QIcon(os.path.join(PATH, "images/spritze.ico")))
-        self.setWindowTitle('vaccipy ' + get_current_version())
+        try:
+            self.setWindowTitle('vaccipy ' + get_current_version())
+        except Exception as error:
+            #Standardwert ist vaccipy
+            pass
 
         # Meldung falls alte Daten von alter Version
         self.__check_old_kontakt_version()


### PR DESCRIPTION
Wenn keine version.txt vorhanden ist, startet das GUI nicht

...hab ich bei #342 übersehen