### PR TITLE
fix(GUI Pfadauswahl): GUI stürz beim "x" drücken während der Pfadauswahl ab

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -231,7 +231,7 @@ class HauptGUI(QtWidgets.QMainWindow):
             try:
                 pfad = oeffne_file_dialog_select(self, "Kontakdaten", self.pfad_kontaktdaten)
             except FileNotFoundError:
-                pass
+                return
 
         self.pfad_kontaktdaten = pfad
         self.i_kontaktdaten_pfad.setText(self.pfad_kontaktdaten)

--- a/tools/gui/qtkontakt.py
+++ b/tools/gui/qtkontakt.py
@@ -129,6 +129,7 @@ class QtKontakt(QtWidgets.QDialog):
 
         except (TypeError, IOError, FileNotFoundError) as error:
             QtWidgets.QMessageBox.critical(self, "Fehler beim Speichern!", "Bitte erneut versuchen!")
+            return
 
         except ValidationError as error:
             QtWidgets.QMessageBox.critical(self, "Daten Fehlerhaft!", f"In den angegebenen Daten sind Fehler:\n\n{error}")


### PR DESCRIPTION
Problem
-
Aktuell ist es so, dass wenn man bei der Auswahl einer anderen JSON-Datei auf "x"- Drückt das GUI crashed:
![image](https://user-images.githubusercontent.com/58706771/121019727-fd664e80-c79f-11eb-95ff-028b51476035.png)

---
Problem wurde nun behoben
Bitte auch noch #348 mergen, da dies bei direktem clonen des Repo zu einem crash des GUI führt