### PR TITLE
NameError Exception fix #367

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -630,7 +630,7 @@ class ImpfterminService():
         elif res.status_code == 401:
             self.log.error(f"Terminpaare können nicht geladen werden: Impf-Code kann nicht für "
                            f"die PLZ '{plz}' verwendet werden.")
-            quit()
+            sys.exit()
         else:
             self.log.error(f"Terminpaare können nicht geladen werden: {res.text}")
         return False, res.status_code


### PR DESCRIPTION
Fixed NameError exception due to quit() call. Replaced with sys.exit().