### PR TITLE
fix(GUI error pop up): Don't throw and show error if loading of data was cancelled by the user

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -294,6 +294,9 @@ class HauptGUI(QtWidgets.QMainWindow):
             except FileNotFoundError:
                 return
 
+        if pfad is None:
+            return
+
         self.pfad_kontaktdaten = pfad
         self.i_kontaktdaten_pfad.setText(self.pfad_kontaktdaten)
 

--- a/tools/gui/__init__.py
+++ b/tools/gui/__init__.py
@@ -1,6 +1,7 @@
 import os
 import json
 import platform
+from typing import Optional
 
 from PyQt5 import QtWidgets, uic
 from PyQt5.QtWidgets import QMessageBox
@@ -41,7 +42,7 @@ def oeffne_file_dialog_save(parent_widged: QtWidgets.QWidget, titel: str, standa
     return dateipfad
 
 
-def oeffne_file_dialog_select(parent_widged: QtWidgets.QWidget, titel: str, standard_oeffnungspfad: str, dateityp="JSON Files (*.json)") -> str:
+def oeffne_file_dialog_select(parent_widged: QtWidgets.QWidget, titel: str, standard_oeffnungspfad: str, dateityp="JSON Files (*.json)") -> Optional[str]:
     """
     Öffnet einen File Dialog um eine existierende Datei auszuwählen
 
@@ -65,6 +66,9 @@ def oeffne_file_dialog_select(parent_widged: QtWidgets.QWidget, titel: str, stan
         options |= QtWidgets.QFileDialog.DontUseNativeDialog
 
     datei_data = QtWidgets.QFileDialog.getOpenFileName(parent=parent_widged, caption=titel, directory=standard_oeffnungspfad, filter=dateityp, options=options)
+    # Open dialog wurde abgebrochen
+    if datei_data == ('', ''):
+        return None
     dateipfad = datei_data[0]  # (pfad, typ)
 
     dateipfad = dateipfad.replace("/", os.path.sep)

--- a/tools/gui/qtkontakt.py
+++ b/tools/gui/qtkontakt.py
@@ -179,6 +179,9 @@ class QtKontakt(QtWidgets.QDialog):
                                 info="Die von Ihnen gewählte Datei konne nicht geöffnet werden.")
             return
 
+        if speicherpfad is None:
+            return
+
         self.standard_speicherpfad = speicherpfad
         self.update_path.emit(speicherpfad)
 


### PR DESCRIPTION
Es wird keine Fehlermeldung mehr angezeigt, wenn das Laden von Kontaktdaten in der UI durch den Benutzer abgebrochen wird.