### PR TITLE
feat(notifications): Fire notification as soon as an appointment was found

### DIFF
--- a/tools/its.py
+++ b/tools/its.py
@@ -970,11 +970,15 @@ class ImpfterminService():
         tp_angenommen = choice(terminpaare_angenommen)
         self.log.success(f"Termin gefunden!")
         self.log.success(f"'{zentrumsname}' in {plz} {ort}")
+        msg = f"'{zentrumsname}' in {plz} {ort}\n"
         for num, termin in enumerate(tp_angenommen, 1):
             ts = datetime.fromtimestamp(termin["begin"] / 1000).strftime(
                 '%d.%m.%Y um %H:%M Uhr')
             self.log.success(f"{num}. Termin: {ts}")
+            msg += f"{num}. Termin: {ts}\n"
         self.log.success(f"Link: {url}impftermine/suche/{code}/{plz}")
+        msg += f"Link: {url}impftermine/suche/{code}/{plz}"
+        self.notify(title="Termin gefunden:", msg=msg)
 
         # Reservierungs-Objekt besteht aus Terminpaar und Impfzentrum
         return {

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -235,7 +235,7 @@ def fire_notifications(notifications: dict, operating_system: str, title: str, m
     if 'pushover' in notifications:
         pushover_notification(notifications["pushover"], title, message)
     if 'telegram' in notifications:
-        telegram_notification(notifications["telegram"], message)
+        telegram_notification(notifications["telegram"], title + "\n" + message)
 
 
 def unique(seq):


### PR DESCRIPTION
Da es ja derzeit vermehrt auftritt, dass Termine nicht automatisch gebucht werden (können), habe ich mal hinzugefügt, dass die Notifications direkt nachdem ein passender Termin gefunden wurde, gefeuert werden. Der Link zur manuellen Buchung wird gleich mit gesendet, somit hat man dann die Chance rechtzeitig manuell einzugreifen. Dank der Telegram Anbindung auch unterwegs...